### PR TITLE
Random Teams Permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+1.1.1 (August 5, 2018)
+- Prevent usage of random teams tool to users who have a role that allows
+  them to move players in their server.
+
 1.1.0 (August 4, 2018)
 - Update random team creation utility.
     - Team creation now stores teams information in local JSON file.

--- a/scripts/randomTeams.js
+++ b/scripts/randomTeams.js
@@ -12,6 +12,11 @@ const DATA_FILE = "../storage/randomTeams.json";
  * @param {String} message is the Discord `message` object.
  */
 function randomTeams(client, message) {
+  if (!message.member.hasPermission("MOVE_MEMBERS")) {
+    message.reply("You must have permission to move users in this server to use random team commands.")
+    return;
+  }
+  
   let messageArray = message.content.split(" ");
   messageArray.splice(0,1); // Remove triggering command
 


### PR DESCRIPTION
- Prevent usage of random teams tool to users who have a role that allows
  them to move players in their server.